### PR TITLE
update tegola vector style to load in land polygons and parse  osm2pgsql data into long date ints 

### DIFF
--- a/vector/antique.toml
+++ b/vector/antique.toml
@@ -1,4 +1,4 @@
-# Copyright 2008-2020 Tim Waters
+# Copyright 2020 Tim Waters
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,66 +37,74 @@ srid = 3857             # The default srid for this provider. If not provided it
   geometry_fieldname = "geom"
   geometry_type = "polygon"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, name, start_date, end_date, water, waterway, ST_AsBinary(way) AS geom FROM planet_osm_polygon WHERE (water IN ('river','canal','lake','water') OR waterway IN ('riverbank','canal','lake','pond') OR \"natural\"='water') AND way && !BBOX!"
+  sql = "SELECT osm_id, name, start_date, end_date, start_date_int, end_date_int, water, waterway, ST_AsBinary(way) AS geom FROM planet_osm_polygon WHERE (water IN ('river','canal','lake','water') OR waterway IN ('riverbank','canal','lake','pond') OR \"natural\"='water') AND way && !BBOX!"
 
   [[providers.layers]]
   name = "water_line"
   geometry_fieldname = "geom"
   geometry_type = "linestring"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, name, start_date, end_date, waterway, ST_AsBinary(way) AS geom FROM planet_osm_line WHERE waterway IN ('river','canal','stream') AND way && !BBOX!"
+  sql = "SELECT osm_id, name, start_date, end_date, start_date_int, end_date_int, waterway, ST_AsBinary(way) AS geom FROM planet_osm_line WHERE waterway IN ('river','canal','stream') AND way && !BBOX!"
 
   [[providers.layers]]
   name = "landuse"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, name, start_date, end_date, landuse, leisure, ST_AsBinary(way) AS geom, name, COALESCE(landuse,leisure) AS type FROM planet_osm_polygon WHERE (landuse IS NOT NULL OR leisure IS NOT NULL) AND way && !BBOX!"
+  sql = "SELECT osm_id, name, start_date, end_date, start_date_int, end_date_int, landuse, leisure, ST_AsBinary(way) AS geom, name, COALESCE(landuse,leisure) AS type FROM planet_osm_polygon WHERE (landuse IS NOT NULL OR leisure IS NOT NULL) AND way && !BBOX!"
 
   [[providers.layers]]
   name = "minor_roads"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IN ('footway','service') AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IN ('footway','service') AND way && !BBOX!"
 
   [[providers.layers]]
   name = "roads"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date,  highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IS NOT NULL AND highway NOT IN ('footway','service') AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IS NOT NULL AND highway NOT IN ('footway','service') AND way && !BBOX!"
 
   [[providers.layers]]
   name = "buildings"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, amenity, tourism, building, \"building:levels\",  tags->'addr:street' AS street, \"addr:housename\" as housename, \"addr:housenumber\" as housenumber,  ST_AsBinary(way) AS geom, name, COALESCE(amenity,tourism,building) AS type, '' AS subtype FROM planet_osm_polygon WHERE building IS NOT NULL AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, amenity, tourism, building, \"building:levels\",  tags->'addr:street' AS street, \"addr:housename\" as housename, \"addr:housenumber\" as housenumber,  ST_AsBinary(way) AS geom, name, COALESCE(amenity,tourism,building) AS type, '' AS subtype FROM planet_osm_polygon WHERE building IS NOT NULL AND way && !BBOX!"
   # note that we should have a subtype here
 
   [[providers.layers]]
   name = "road_names"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name FROM planet_osm_line WHERE highway IS NOT NULL AND name IS NOT NULL AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name FROM planet_osm_line WHERE highway IS NOT NULL AND name IS NOT NULL AND way && !BBOX!"
 
   [[providers.layers]]
   name = "places"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, place, ST_AsBinary(way) AS geom, UPPER(name) AS name, place AS type FROM planet_osm_point WHERE place IS NOT NULL AND name IS NOT NULL AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, place, ST_AsBinary(way) AS geom, UPPER(name) AS name, place AS type FROM planet_osm_point WHERE place IS NOT NULL AND name IS NOT NULL AND way && !BBOX!"
 
 
-	#ne water, ocean and lakes
+	#osm land
 	[[providers.layers]]
-	name = "ne_50m_water"
+	name = "osm_land"
 	geometry_fieldname = "geom"
 	id_fieldname = "ogc_fid"
-	sql = "SELECT ST_AsBinary(geom) AS geom, ogc_fid FROM  ne_50m_ocean_gridded WHERE min_zoom <= !ZOOM! AND geom && !BBOX! UNION ALL SELECT ST_AsBinary(geom) AS geom, ogc_fid FROM ne_50m_lakes WHERE min_zoom <= !ZOOM! AND geom && !BBOX!"
+	sql = "SELECT ST_AsBinary(geom) AS geom, ogc_fid,  osm_id, start_date, end_date, start_date_int, end_date_int FROM  land_polygons_sub WHERE geom && !BBOX!"
 
 	[[providers.layers]]
-	name = "ne_10m_water"
+	name = "simplified_osm_land"
 	geometry_fieldname = "geom"
 	id_fieldname = "ogc_fid"
-	geometry_type = "multipolygon"
-	sql = "SELECT ST_AsBinary(geom) AS geom, ogc_fid FROM  ne_10m_ocean_gridded_edited where geom && !BBOX! "
+	sql = "SELECT ST_AsBinary(geom) AS geom, ogc_fid,  osm_id, start_date, end_date, start_date_int, end_date_int FROM  simplified_land_polygons_sub WHERE geom && !BBOX!"
+
+
+	#ne land
+	[[providers.layers]]
+	name = "ne_10m_land"
+	geometry_fieldname = "geom"
+	id_fieldname = "ogc_fid"
+	sql = "SELECT ST_AsBinary(geom) AS geom, ogc_fid FROM  ne_10m_land_subdivided WHERE geom && !BBOX!"
+
 
 	[[providers.layers]]
 	name = "ne_10m_lakes"
@@ -154,10 +162,12 @@ srid = 3857             # The default srid for this provider. If not provided it
 [[maps]]
 name = "antique"
 center = [0.0,51.5,14.0]
+attribution = "Coastlines © OpenStreetMap contributors"
 
   [[maps.layers]]
+	name = "water"
   provider_layer = "antique.water"
-  min_zoom = 12
+  min_zoom = 10
   max_zoom = 20
 
   [[maps.layers]]
@@ -198,28 +208,34 @@ center = [0.0,51.5,14.0]
 
   # Natural Earth data
 
-
-	# ocean & lakes
-
+	# land
 	[[maps.layers]]
-	name = "ocean"
-	provider_layer = "antique.ne_50m_water"
+	name = "land"
+	provider_layer = "antique.ne_10m_land"
 	dont_simplify = true
 	min_zoom = 0
-	max_zoom = 4
+	max_zoom = 7
 
 	[[maps.layers]]
-	name = "ocean"
-	provider_layer = "antique.ne_10m_water"
+	name = "land"
+	provider_layer = "antique.simplified_osm_land"
 	dont_simplify = true
-	min_zoom = 5
+	min_zoom = 8
+	max_zoom = 11
+
+	[[maps.layers]]
+	name = "land"
+	provider_layer = "antique.osm_land"
+	dont_simplify = true
+	min_zoom = 12
 	max_zoom = 20
+
 
 	[[maps.layers]]
 	name = "lakes"
 	provider_layer = "antique.ne_10m_lakes"
 	min_zoom = 5
-	max_zoom = 11
+	max_zoom = 15
 
 
 # borders

--- a/vector/osm2pgsql.style
+++ b/vector/osm2pgsql.style
@@ -153,7 +153,11 @@ node,way   z_order      int4         linear # This is calculated during import
 way        way_area     real         linear # This is calculated during import
 node,way   start_date   text         linear
 node,way   end_date     text         linear
+node,way   start_date_int   text         linear
+node,way   end_date_int     text         linear
 node,way   building:levels   text         linear
+
+
 
 # Area tags
 # We don't make columns for these tags, but objects with them are areas.

--- a/vector/tag_transforms.lua
+++ b/vector/tag_transforms.lua
@@ -1,0 +1,170 @@
+function filter_tags_dates(keyvalues, nokeys)
+  filter = 0
+  tagcount = 0
+
+  if nokeys == 0 then
+     filter = 1
+     return filter, keyvalues
+  end
+  start_date_int = "-Infinity"
+  end_date_int = "Infinity"
+  
+ if (keyvalues["start_date"] ~= nil ) or (keyvalues["end_date"] ~= nil ) then
+  keyvalues["start_date_int"] = start_date_int
+  keyvalues["end_date_int"] = end_date_int
+  end
+
+  if (keyvalues["start_date"] ~= nil ) then
+   year,month,day = nil
+   year = string.match(keyvalues["start_date"], "^(-?%d+%d%d%d)")
+
+     if (year ~= nil) then
+       y, month = string.match(keyvalues["start_date"], "^(-?%d+%d%d%d)-(%d%d)")
+       
+       if (month == nil) then
+         month = "00"
+         day = "00"
+       else
+         y, m, day = string.match(keyvalues["start_date"], "^(-?%d+%d%d%d)-(%d%d)-(%d%d)")
+         if (day == nil) then
+           day = "00"
+         end
+
+       end
+
+         year = string.sub(year, 0, 4)
+         month = string.sub(month, 0, 2)
+         day = string.sub(day, 0, 2)
+         start_date_int = year..month..day
+         keyvalues["start_date_int"] =  start_date_int
+       else
+         keyvalues["start_date_int"] = "-Infinity"
+     end
+ end
+ 
+ if (keyvalues["end_date"] ~= nil ) then
+   year,month,day = nil
+   year = string.match(keyvalues["end_date"], "^(-?%d+%d%d%d)")
+
+     if (year ~= nil) then
+       y, month = string.match(keyvalues["end_date"], "^(-?%d+%d%d%d)-(%d%d)")
+       if (month == nil) then
+         month = "00"
+         day = "00"
+       else
+         y, m, day = string.match(keyvalues["end_date"], "^(-?%d+%d%d%d)-(%d%d)-(%d%d)")
+         if (day == nil) then
+           day = "00"
+         end
+
+       end
+
+         year = string.sub(year, 0, 4)
+         month = string.sub(month, 0, 2)
+         day = string.sub(day, 0, 2)
+         end_date_int = year..month..day
+         keyvalues["end_date_int"] =  end_date_int
+       else
+        
+         keyvalues["end_date_int"] = "Infinity"
+     end
+ end
+
+  return filter, keyvalues
+end
+
+
+-- Filtering on nodes
+-- we just want place, name
+function filter_tags_node (tags, numberofkeys)
+
+  filters, tags = filter_tags_dates(tags, numberofkeys)
+
+	local filter = 0
+	if not tags['place'] then filter = 1 end
+    return filter, tags
+end
+
+-- Filtering on relations: just multipolygons
+-- (note that the current dataset doesn't have any multipolygons)
+function filter_basic_tags_rel (tags, numberofkeys)
+    filter, tags = filter_tags_dates(tags, numberofkeys)
+    if tags["type"] ~= "multipolygon" then return 1, tags end
+    return 0, tags
+end
+
+-- Filtering on ways
+--	Columns in planet_osm_polygon:
+--	- building (amenity | building | industrial | shop | tourism)
+--	- type (i.e. shop type, religion type)
+--	- landuse (landuse | leisure) <--- note that we shouldn't set landuse if there's a building tag
+--	- name
+--	Columns in planet_osm_line:
+--	- highway
+--	- natural (=coastline)
+
+function filter_tags_way (tags, numberofkeys)
+
+    local filter = 0  -- Will object be filtered out?
+    local polygon = 0 -- Will object be treated as polygon?
+    local roads = 0   -- Will object be added to planet_osm_roads?
+    local type = nil
+    local landuse = nil
+  
+    filter, tags = filter_tags_dates(tags, numberofkeys)
+
+	-- Collapse into building/landuse tags
+	local building = tags["amenity"] or tags["industrial"] or tags["tourism"] or tags["building"] 
+	if tags["shop"] then building="shop"; type=tags["shop"] end
+	if not building then landuse = tags["landuse"] or tags["leisure"] end
+	tags['type'] = type or tags["religion"]
+	if building or landuse then 
+		tags["building"] = building
+		tags["landuse"]  = landuse
+		return 0, tags, 1, 0
+	end
+
+	-- Otherwise, is it a highway or a coastline?
+	if tags["highway"] or tags["natural"] == "coastline" then
+		return 0, tags, 0, 0
+  end
+  
+  if tags["natural"] == "water" then
+    return 0, tags, 1, 0
+  end
+
+	-- Not something we recognise
+	return 1, tags, 0, 0
+end
+
+function filter_tags_relation_member (tags, keyvaluemembers, roles, membercount)
+    filter = 0     -- Will object be filtered out?
+    linestring = 0 -- Will object be treated as linestring?
+    polygon = 0    -- Will object be treated as polygon?
+    roads = 0      -- Will object be added to planet_osm_roads?
+    
+	membersuperseded = {}
+	for i = 1, membercount do
+		membersuperseded[i] = 0
+	end
+
+    type = tags["type"]
+
+    -- Remove type key
+    tags["type"] = nil
+
+    -- Relations with type=boundary are treated as linestring
+    if (type == "boundary") then
+        linestring = 1
+    end
+    -- Relations with type=multipolygon and boundary=* are treated as linestring
+    if ((type == "multipolygon") and tags["boundary"]) then
+        linestring = 1
+    -- For multipolygons...
+    elseif (type == "multipolygon") then
+        -- Treat as polygon
+        polygon = 1
+    end
+
+    return filter, tags, membersuperseded, linestring, polygon, roads
+end

--- a/vector/tegola-config.toml
+++ b/vector/tegola-config.toml
@@ -1,4 +1,4 @@
-# Copyright 2008-2020 Tim Waters
+# Copyright 2020 Tim Waters
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,71 +37,79 @@ user = "${DB_USER}"          # postgis database user
 password = "${DB_PASSWORD}"  # postgis database password
 srid = 3857                  # The default srid for this provider. If not provided it will be WebMercator (3857)
 
-  [[providers.layers]]
+ [[providers.layers]]
   name = "water"
   geometry_fieldname = "geom"
   geometry_type = "polygon"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, name, start_date, end_date, water, waterway, ST_AsBinary(way) AS geom FROM planet_osm_polygon WHERE (water IN ('river','canal','lake','water') OR waterway IN ('riverbank','canal','lake','pond') OR \"natural\"='water') AND way && !BBOX!"
+  sql = "SELECT osm_id, name, start_date, end_date, start_date_int, end_date_int, water, waterway, ST_AsBinary(way) AS geom FROM planet_osm_polygon WHERE (water IN ('river','canal','lake','water') OR waterway IN ('riverbank','canal','lake','pond') OR \"natural\"='water') AND way && !BBOX!"
 
   [[providers.layers]]
   name = "water_line"
   geometry_fieldname = "geom"
   geometry_type = "linestring"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, name, start_date, end_date, waterway, ST_AsBinary(way) AS geom FROM planet_osm_line WHERE waterway IN ('river','canal','stream') AND way && !BBOX!"
+  sql = "SELECT osm_id, name, start_date, end_date, start_date_int, end_date_int, waterway, ST_AsBinary(way) AS geom FROM planet_osm_line WHERE waterway IN ('river','canal','stream') AND way && !BBOX!"
 
   [[providers.layers]]
   name = "landuse"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, name, start_date, end_date, landuse, leisure, ST_AsBinary(way) AS geom, name, COALESCE(landuse,leisure) AS type FROM planet_osm_polygon WHERE (landuse IS NOT NULL OR leisure IS NOT NULL) AND way && !BBOX!"
+  sql = "SELECT osm_id, name, start_date, end_date, start_date_int, end_date_int, landuse, leisure, ST_AsBinary(way) AS geom, name, COALESCE(landuse,leisure) AS type FROM planet_osm_polygon WHERE (landuse IS NOT NULL OR leisure IS NOT NULL) AND way && !BBOX!"
 
   [[providers.layers]]
   name = "minor_roads"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IN ('footway','service') AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IN ('footway','service') AND way && !BBOX!"
 
   [[providers.layers]]
   name = "roads"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date,  highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IS NOT NULL AND highway NOT IN ('footway','service') AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IS NOT NULL AND highway NOT IN ('footway','service') AND way && !BBOX!"
 
   [[providers.layers]]
   name = "buildings"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, amenity, tourism, building, \"building:levels\",  tags->'addr:street' AS street, \"addr:housename\" as housename, \"addr:housenumber\" as housenumber,  ST_AsBinary(way) AS geom, name, COALESCE(amenity,tourism,building) AS type, '' AS subtype FROM planet_osm_polygon WHERE building IS NOT NULL AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, amenity, tourism, building, \"building:levels\",  tags->'addr:street' AS street, \"addr:housename\" as housename, \"addr:housenumber\" as housenumber,  ST_AsBinary(way) AS geom, name, COALESCE(amenity,tourism,building) AS type, '' AS subtype FROM planet_osm_polygon WHERE building IS NOT NULL AND way && !BBOX!"
   # note that we should have a subtype here
 
   [[providers.layers]]
   name = "road_names"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name FROM planet_osm_line WHERE highway IS NOT NULL AND name IS NOT NULL AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name FROM planet_osm_line WHERE highway IS NOT NULL AND name IS NOT NULL AND way && !BBOX!"
 
   [[providers.layers]]
   name = "places"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, place, ST_AsBinary(way) AS geom, UPPER(name) AS name, place AS type FROM planet_osm_point WHERE place IS NOT NULL AND name IS NOT NULL AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, place, ST_AsBinary(way) AS geom, UPPER(name) AS name, place AS type FROM planet_osm_point WHERE place IS NOT NULL AND name IS NOT NULL AND way && !BBOX!"
 
 
-	#ne water, ocean and lakes
+	#osm land
 	[[providers.layers]]
-	name = "ne_50m_water"
+	name = "osm_land"
 	geometry_fieldname = "geom"
 	id_fieldname = "ogc_fid"
-	sql = "SELECT ST_AsBinary(geom) AS geom, ogc_fid FROM  ne_50m_ocean_gridded WHERE min_zoom <= !ZOOM! AND geom && !BBOX! UNION ALL SELECT ST_AsBinary(geom) AS geom, ogc_fid FROM ne_50m_lakes WHERE min_zoom <= !ZOOM! AND geom && !BBOX!"
+	sql = "SELECT ST_AsBinary(geom) AS geom, ogc_fid,  osm_id, start_date, end_date, start_date_int, end_date_int FROM  land_polygons_sub WHERE geom && !BBOX!"
 
 	[[providers.layers]]
-	name = "ne_10m_water"
+	name = "simplified_osm_land"
 	geometry_fieldname = "geom"
 	id_fieldname = "ogc_fid"
-	geometry_type = "multipolygon"
-	sql = "SELECT ST_AsBinary(geom) AS geom, ogc_fid FROM  ne_10m_ocean_gridded_edited where geom && !BBOX! "
+	sql = "SELECT ST_AsBinary(geom) AS geom, ogc_fid,  osm_id, start_date, end_date, start_date_int, end_date_int FROM  simplified_land_polygons_sub WHERE geom && !BBOX!"
+
+
+	#ne land
+	[[providers.layers]]
+	name = "ne_10m_land"
+	geometry_fieldname = "geom"
+	id_fieldname = "ogc_fid"
+	sql = "SELECT ST_AsBinary(geom) AS geom, ogc_fid FROM  ne_10m_land_subdivided WHERE geom && !BBOX!"
+
 
 	[[providers.layers]]
 	name = "ne_10m_lakes"
@@ -159,10 +167,12 @@ srid = 3857                  # The default srid for this provider. If not provid
 [[maps]]
 name = "antique"
 center = [0.0,51.5,14.0]
+attribution = "Coastlines © OpenStreetMap contributors"
 
   [[maps.layers]]
+	name = "water"
   provider_layer = "antique.water"
-  min_zoom = 12
+  min_zoom = 10
   max_zoom = 20
 
   [[maps.layers]]
@@ -203,28 +213,34 @@ center = [0.0,51.5,14.0]
 
   # Natural Earth data
 
-
-	# ocean & lakes
-
+	# land
 	[[maps.layers]]
-	name = "ocean"
-	provider_layer = "antique.ne_50m_water"
+	name = "land"
+	provider_layer = "antique.ne_10m_land"
 	dont_simplify = true
 	min_zoom = 0
-	max_zoom = 4
+	max_zoom = 7
 
 	[[maps.layers]]
-	name = "ocean"
-	provider_layer = "antique.ne_10m_water"
+	name = "land"
+	provider_layer = "antique.simplified_osm_land"
 	dont_simplify = true
-	min_zoom = 5
+	min_zoom = 8
+	max_zoom = 11
+
+	[[maps.layers]]
+	name = "land"
+	provider_layer = "antique.osm_land"
+	dont_simplify = true
+	min_zoom = 12
 	max_zoom = 20
+
 
 	[[maps.layers]]
 	name = "lakes"
 	provider_layer = "antique.ne_10m_lakes"
 	min_zoom = 5
-	max_zoom = 11
+	max_zoom = 15
 
 
 # borders


### PR DESCRIPTION
This PR updates the tegola style to include land polygons. Updates also the osm2pgsql style to include start_date_int and end_date_int and uses the lua_transforms to convert start_date to start_date_int for use in filtering dates in the time filter. 