### PR TITLE
Do not query for tunnels. Remove unused fields from some buildings. Fix paths and steps for roads.

### DIFF
--- a/vector/antique.toml
+++ b/vector/antique.toml
@@ -56,26 +56,31 @@ srid = 3857             # The default srid for this provider. If not provided it
   name = "minor_roads"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IN ('footway','service') AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IN ('footway','service', 'steps', 'pedestrian') AND way && !BBOX!"
 
   [[providers.layers]]
   name = "roads"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IS NOT NULL AND highway NOT IN ('footway','service') AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IS NOT NULL AND highway NOT IN ('footway','service', 'steps', 'pedestrian') AND tunnel IS NULL AND way && !BBOX!"
+
+  [[providers.layers]]
+  name = "major_roads"
+  geometry_fieldname = "geom"
+  id_fieldname = "osm_id"
+  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IS NOT NULL AND highway IN ('motorway', 'primary', 'trunk') AND tunnel IS NULL AND way && !BBOX!"
 
   [[providers.layers]]
   name = "buildings"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, amenity, tourism, building, \"building:levels\",  tags->'addr:street' AS street, \"addr:housename\" as housename, \"addr:housenumber\" as housenumber,  ST_AsBinary(way) AS geom, name, COALESCE(amenity,tourism,building) AS type, '' AS subtype FROM planet_osm_polygon WHERE building IS NOT NULL AND way && !BBOX!"
-  # note that we should have a subtype here
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, ST_AsBinary(way) AS geom, name, COALESCE(amenity,tourism,building) AS type FROM planet_osm_polygon WHERE building IS NOT NULL AND way && !BBOX!"
 
   [[providers.layers]]
   name = "road_names"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name FROM planet_osm_line WHERE highway IS NOT NULL AND name IS NOT NULL AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, start_date_int, end_date_int, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name FROM planet_osm_line WHERE highway IS NOT NULL AND highway IN ('motorway', 'primary', 'trunk', 'secondary', 'residential') AND tunnel IS NULL AND name IS NOT NULL AND way && !BBOX!"
 
   [[providers.layers]]
   name = "places"
@@ -177,7 +182,7 @@ attribution = "Coastlines © OpenStreetMap contributors"
 
   [[maps.layers]]
   provider_layer = "antique.minor_roads"
-  min_zoom = 12
+  min_zoom = 16
   max_zoom = 20
 
   [[maps.layers]]
@@ -187,17 +192,22 @@ attribution = "Coastlines © OpenStreetMap contributors"
 
   [[maps.layers]]
   provider_layer = "antique.roads"
-  min_zoom = 12
+  min_zoom = 13
   max_zoom = 20
 
   [[maps.layers]]
+  provider_layer = "antique.major_roads"
+  min_zoom = 8
+  max_zoom = 12
+
+  [[maps.layers]]
   provider_layer = "antique.buildings"
-  min_zoom = 12
+  min_zoom = 15
   max_zoom = 20
 
   [[maps.layers]]
   provider_layer = "antique.road_names"
-  min_zoom = 12
+  min_zoom = 13
   max_zoom = 20
 
   [[maps.layers]]

--- a/vector/tegola-config.toml
+++ b/vector/tegola-config.toml
@@ -62,32 +62,31 @@ srid = 3857                  # The default srid for this provider. If not provid
   name = "minor_roads"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IN ('footway','service') AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IN ('footway','service', 'steps', 'pedestrian') AND way && !BBOX!"
 
   [[providers.layers]]
   name = "roads"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IS NOT NULL AND highway NOT IN ('footway','service') AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IS NOT NULL AND highway NOT IN ('footway','service','steps', 'pedestrian') AND tunnel IS NULL AND way && !BBOX!"
 
   [[providers.layers]]
   name = "major_roads"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IS NOT NULL AND highway IN ('motorway', 'primary', 'trunk') AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name, highway AS type FROM planet_osm_line WHERE highway IS NOT NULL AND highway IN ('motorway', 'primary', 'trunk')  AND tunnel IS NULL AND way && !BBOX!"
 
   [[providers.layers]]
   name = "buildings"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, amenity, tourism, building, \"building:levels\",  tags->'addr:street' AS street, \"addr:housename\" as housename, \"addr:housenumber\" as housenumber,  ST_AsBinary(way) AS geom, name, COALESCE(amenity,tourism,building) AS type, '' AS subtype FROM planet_osm_polygon WHERE building IS NOT NULL AND way && !BBOX!"
-  # note that we should have a subtype here
+  sql = "SELECT osm_id, start_date, end_date, ST_AsBinary(way) AS geom, name, COALESCE(amenity,tourism,building) AS type FROM planet_osm_polygon WHERE building IS NOT NULL AND way && !BBOX!"
 
   [[providers.layers]]
   name = "road_names"
   geometry_fieldname = "geom"
   id_fieldname = "osm_id"
-  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name FROM planet_osm_line WHERE highway IS NOT NULL AND name IS NOT NULL AND way && !BBOX!"
+  sql = "SELECT osm_id, start_date, end_date, highway, ST_AsBinary(way) AS geom, UPPER(name) AS name FROM planet_osm_line WHERE highway IS NOT NULL AND highway IN ('motorway', 'primary', 'trunk', 'secondary', 'residential') AND tunnel IS NULL AND name IS NOT NULL AND way && !BBOX!"
 
   [[providers.layers]]
   name = "places"


### PR DESCRIPTION
This PR removes tunnels from the roads queries, to fix: 
https://github.com/kartta-labs/kartta/issues/34

It also removes a few un-used address fields from the buildings queries to make tiles a bit smaller.

It also fixes footpaths and steps being put in the correct layer. They should now be in the minor roads layer shown as a dashed line and explicitly excluded from the roads layer. 

Only roads will be labelled if they are in: 'motorway', 'primary', 'trunk', 'secondary', 'residential'  (i.e. not a footpath or service road)

Oh, and it also applies the previous recent commits to the local tegola config for convenience  